### PR TITLE
Fix hook to run only on files ending with .mo

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,4 +3,4 @@
   description: Make your Modelica code pretty
   entry: mofmt
   language: python
-  files: '.*\.mo'
+  files: '.*\.mo$'


### PR DESCRIPTION
Currently pre-commit runs mofmt on all files containing `.mo`, which is especially bad for `.mos` files.

This small change ensures that only files ending with `.mo` are formatted.  