### PR TITLE
Bugfix: Bad indent for annotations after empty sections

### DIFF
--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -496,7 +496,12 @@ fn composition(f: &mut Formatter, tree: Tree) {
                 }
                 SyntaxKind::AnnotationClause => {
                     f.markers.push(Marker::Indent);
-                    let extern_element_annotation = f.prev_tok != ModelicaToken::Semicolon;
+                    let extern_element_annotation = [
+                        ModelicaToken::RParen,
+                        ModelicaToken::External,
+                        ModelicaToken::String,
+                    ]
+                    .contains(&f.prev_tok);
                     if extern_element_annotation {
                         f.markers.push(Marker::Indent);
                     }

--- a/tests/samples/code-input.mo
+++ b/tests/samples/code-input.mo
@@ -200,6 +200,10 @@ external"C" foo[1].bar [2] = baz(x
 annotation (Library="doesn't matter");
 annotation (smoothOrder = 2);
 end Foo;
+impure function Baz "To check annotations after empty sections"
+algorithm
+annotation ();
+end Baz;
 partial function Bar "Just in case"
   initial algorithm
 

--- a/tests/samples/code-output.mo
+++ b/tests/samples/code-output.mo
@@ -285,6 +285,14 @@ external "C"
   annotation (smoothOrder = 2);
 
 end Foo;
+impure function Baz
+  "To check annotations after empty sections"
+
+algorithm
+
+  annotation ();
+
+end Baz;
 partial function Bar
   "Just in case"
 


### PR DESCRIPTION
Fixes #31

The issue was caused by wrong heuristic used to differentiate between external function all annotation and "class" annotation inside the *composition* production.