### PR TITLE
Feature: Check mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,16 +3,17 @@ use moparse::{parse, SyntaxKind};
 use std::path::{Path, PathBuf};
 use std::{env, fs};
 
-const VERSION: &str = "0.4.2";
+const VERSION: &str = "0.5.0";
 
 const HELP: &str = r#"
 mofmt: Modelica code formatter
 
-Usage: mofmt SRC ...
+Usage: mofmt [OPTIONS] <PATHS>
 
 Options:
 -h, --help: display this message and exit
 -v, --version: display a version number and exit
+--check: run mofmt in check mode
 "#;
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,9 @@ fn main() {
             std::process::exit(1);
         }
         format_files(&args[2..], true);
+    } else if args[1].starts_with("-") {
+        eprintln!("Unrecognized option: '{}'.\n{}", args[1], HELP);
+        std::process::exit(1);
     } else {
         format_files(&args[1..], false);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ Options:
 fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
-        eprintln!("{}", HELP);
+        eprintln!("Missing PATHS arguments.\n{}", HELP);
         std::process::exit(1);
     } else if ["-h", "--help"].contains(&args[1].as_str()) {
         println!("{}", HELP);

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,12 +27,15 @@ fn main() {
     } else if ["-v", "--version"].contains(&args[1].as_str()) {
         println!("mofmt, {}", VERSION);
         std::process::exit(0);
+    } else if args[1].as_str() == "--check" {
+        format_files(&args[2..], true);
+    } else {
+        format_files(&args[1..], false);
     }
-    format_files(&args[1..]);
 }
 
 /// Format files specified in the argument list
-fn format_files(args: &[String]) {
+fn format_files(args: &[String], check: bool) {
     let mut files = Vec::new();
     args.iter()
         .map(PathBuf::from)

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ Usage: mofmt [OPTIONS] <PATHS>
 Options:
 -h, --help: display this message and exit
 -v, --version: display a version number and exit
---check: run mofmt in check mode
+--check: run mofmt in check mode (without modifying the file)
 "#;
 
 fn main() {
@@ -29,6 +29,10 @@ fn main() {
         println!("mofmt, {}", VERSION);
         std::process::exit(0);
     } else if args[1].as_str() == "--check" {
+        if args.len() < 3 {
+            eprintln!("Missing PATHS arguments.\n{}", HELP);
+            std::process::exit(1);
+        }
         format_files(&args[2..], true);
     } else {
         format_files(&args[1..], false);
@@ -69,6 +73,8 @@ fn format_files(args: &[String], check: bool) {
                         if output != source {
                             code = 1;
                             writeln!(lock, "{}: check failed", p.display()).unwrap();
+                        } else {
+                            writeln!(lock, "{}: check passed", p.display()).unwrap();
                         }
                     } else {
                         write_file(p, output);
@@ -81,6 +87,7 @@ fn format_files(args: &[String], check: bool) {
             }
         }
     });
+    std::process::exit(code);
 }
 
 /// Return all Modelica files from the given directory

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ fn main() {
             std::process::exit(1);
         }
         format_files(&args[2..], true);
-    } else if args[1].starts_with("-") {
+    } else if args[1].starts_with('-') {
         eprintln!("Unrecognized option: '{}'.\n{}", args[1], HELP);
         std::process::exit(1);
     } else {


### PR DESCRIPTION
This PR introduces a check mode.

From now on mofmt can be ran with a `--check` flag. In such case it won't modify the files, but instead check if the formatted code matches the original.

Exit codes 0 and 1 are returned. 1 is returned if any checked file doesn't match.
Status of each file is printed to the stdout.