### PR TITLE
Bugfix: Syntax error when first output is dropped 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["Modelica", "development", "formatter"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-moparse = "0.1.4"
+moparse = "0.1.5-rc1"
 
 [profile.release]
 strip = true

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -2064,6 +2064,9 @@ fn output_expression_list(f: &mut Formatter, tree: Tree, mut wrapped: bool) -> b
         match child {
             Child::Tree(t) => wrapped = expression(f, t, wrapped, true),
             Child::Token(tok) => {
+                if f.prev_tok == ModelicaToken::LParen {
+                    f.markers.push(Marker::Space);  
+                }
                 f.handle_token(tok);
                 f.markers.push(Marker::Space);
             }

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -2065,7 +2065,7 @@ fn output_expression_list(f: &mut Formatter, tree: Tree, mut wrapped: bool) -> b
             Child::Tree(t) => wrapped = expression(f, t, wrapped, true),
             Child::Token(tok) => {
                 if f.prev_tok == ModelicaToken::LParen {
-                    f.markers.push(Marker::Space);  
+                    f.markers.push(Marker::Space);
                 }
                 f.handle_token(tok);
                 f.markers.push(Marker::Space);

--- a/tests/samples/code-input.mo
+++ b/tests/samples/code-input.mo
@@ -181,7 +181,7 @@ algorithm
   (A,B,C):= foo.bar.baz
   (a);
   (D,,E) := foo.bar .baz(b);
-  (F, G,(H,
+  (, G,(H,
   J)) := foo.bar.baz(c);
 
 foo:={{bar[i] + j*

--- a/tests/samples/code-output.mo
+++ b/tests/samples/code-output.mo
@@ -232,7 +232,7 @@ algorithm
 
   (A, B, C) := foo.bar.baz(a);
   (D, , E) := foo.bar.baz(b);
-  (F, G, (H, J)) := foo.bar.baz(c);
+  ( , G, (H, J)) := foo.bar.baz(c);
 
   foo := {
     {


### PR DESCRIPTION
Fixes #39 

It was a bug in the parser, but **mofmt** also needed an update, so that all dropped outputs are handled the same way.