### PR TITLE
Bugfix: Missing filename when panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["Modelica", "development", "formatter"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-moparse = "0.1.5-rc1"
+moparse = "0.1.5-rc2"
 
 [profile.release]
 strip = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,9 +62,18 @@ fn format_files(args: &[String], check: bool) {
         let name = p.display();
         match contents {
             Ok(source) => {
-                let parsed = parse(name.to_string().as_str(), &source, SyntaxKind::StoredDefinition);
+                let parsed = parse(
+                    name.to_string().as_str(),
+                    &source,
+                    SyntaxKind::StoredDefinition,
+                );
                 if !parsed.errors.is_empty() {
-                    writeln!(lock, "Syntax errors detected:\n{}", parsed.errors.join("\n")).unwrap();
+                    writeln!(
+                        lock,
+                        "Syntax errors detected:\n{}",
+                        parsed.errors.join("\n")
+                    )
+                    .unwrap();
                     code = 1;
                 } else {
                     let output = pretty_print(parsed.tokens, parsed.comments, parsed.events);

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,25 +59,21 @@ fn format_files(args: &[String], check: bool) {
         .for_each(|mut v| files.append(&mut v));
     files.iter().for_each(|p| {
         let contents = read_file(p);
+        let name = p.display();
         match contents {
             Ok(source) => {
-                let parsed = parse(&source, SyntaxKind::StoredDefinition);
+                let parsed = parse(name.to_string().as_str(), &source, SyntaxKind::StoredDefinition);
                 if !parsed.errors.is_empty() {
-                    let messages: Vec<String> = parsed
-                        .errors
-                        .iter()
-                        .map(|e| format!("{}:{}", p.display(), e))
-                        .collect();
-                    writeln!(lock, "Syntax errors detected:\n{}", messages.join("\n")).unwrap();
+                    writeln!(lock, "Syntax errors detected:\n{}", parsed.errors.join("\n")).unwrap();
                     code = 1;
                 } else {
                     let output = pretty_print(parsed.tokens, parsed.comments, parsed.events);
                     if check {
                         if output != source {
                             code = 1;
-                            writeln!(lock, "{}: check failed", p.display()).unwrap();
+                            writeln!(lock, "{}: check failed", name).unwrap();
                         } else {
-                            writeln!(lock, "{}: check passed", p.display()).unwrap();
+                            writeln!(lock, "{}: check passed", name).unwrap();
                         }
                     } else {
                         write_file(p, output);
@@ -85,7 +81,7 @@ fn format_files(args: &[String], check: bool) {
                 }
             }
             Err(e) => {
-                eprintln!("{}: error: {}", p.display(), e);
+                eprintln!("{}: error: {}", name, e);
                 code = 1;
             }
         }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -102,7 +102,7 @@ mod tests {
     use super::*;
 
     fn tree(source: &str, start: SyntaxKind) -> Tree {
-        let parsed = parse(source, start);
+        let parsed = parse("none", source, start);
         build_tree(parsed.tokens, parsed.events)
     }
 

--- a/tests/style_tests.rs
+++ b/tests/style_tests.rs
@@ -5,7 +5,7 @@ use std::fs;
 // Helper functions
 fn format_file(path: &str) -> String {
     let input = fs::read_to_string(path).expect("error");
-    let parsed = moparse::parse(&input, moparse::SyntaxKind::StoredDefinition);
+    let parsed = moparse::parse(path, &input, moparse::SyntaxKind::StoredDefinition);
     mofmt::pretty_print(parsed.tokens, parsed.comments, parsed.events)
 }
 


### PR DESCRIPTION
Fixes #43 

Proper fix was done in the `moparse` crate in. This PR contains only adjustments after switching to the newer parser version.